### PR TITLE
Add key to CITATION

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -23,6 +23,7 @@ person_list2 <- "Robitzsch, A., Kiefer, T., & Wu, M."
 citHeader( paste0( "To cite the '", pkg , "' package in publications use:") )
 
 citEntry(entry="Manual",
+         key = tolower(pkg),
          title = paste0( pkg , ": " , pkg_title ) ,
          author = personList( person_list1 ),
          year = year,


### PR DESCRIPTION
Hello,

This minor PR adds a key to the CITATION latex code, which will fix the current citation code that doesn't work without a key (which seems to be common). This would then update https://cran.r-project.org/web/packages/TAM/citation.html once re-published to CRAN.

Cheers,
Chris