### PR TITLE
try to fix bug in SE-estimation for models estimated via QMC

### DIFF
--- a/R/tam_mml_se_quick.R
+++ b/R/tam_mml_se_quick.R
@@ -1,5 +1,5 @@
 ## File Name: tam_mml_se_quick.R
-## File Version: 0.43
+## File Version: 0.44
 
 
 tam_mml_se_quick <- function( tamobj, numdiff.parm=.001, item_pars=TRUE )
@@ -64,7 +64,8 @@ tam_mml_se_quick <- function( tamobj, numdiff.parm=.001, item_pars=TRUE )
                 #-- compute likelihood
                 ll[,mm] <- tam_mml_se_quick_likelihood( nitems=nitems, A=A, AXsi=AXsi, B=B, xsi=xsi0,
                             theta=theta, nnodes=nnodes, maxK=maxK, gwt=gwt0a, resp=resp,
-                            resp.ind.list=resp.ind.list, snodes=snodes, thetawidth=thetawidth )
+                            resp.ind.list=resp.ind.list, snodes=snodes, thetawidth=thetawidth,
+                            thetasamp.density=tamobj$thetasamp.density )
             }
             info_pp <- tam_mml_se_quick_difference_quotient(ll=ll, h=h, pweights=pweights )
             se.xsi[pp] <- sqrt( - 1 / info_pp )
@@ -166,7 +167,8 @@ tam_mml_se_quick <- function( tamobj, numdiff.parm=.001, item_pars=TRUE )
                 #-- compute likelihood
                 ll[,mm] <- tam_mml_se_quick_likelihood( nitems=nitems, A=A, AXsi=AXsi, B=B, xsi=xsi,
                             theta=theta, nnodes=nnodes, maxK=maxK, gwt=gwt0a, resp=resp,
-                            resp.ind.list=resp.ind.list, snodes=snodes, thetawidth=thetawidth )
+                            resp.ind.list=resp.ind.list, snodes=snodes, thetawidth=thetawidth,
+                            thetasamp.density=tamobj$thetasamp.density  )
             }
             info_pp <- tam_mml_se_quick_difference_quotient(ll=ll, h=h, pweights=pweights )
             se.beta[pp,dd] <- sqrt( - 1 /  info_pp )

--- a/R/tam_mml_se_quick_likelihood.R
+++ b/R/tam_mml_se_quick_likelihood.R
@@ -1,9 +1,9 @@
 ## File Name: tam_mml_se_quick_likelihood.R
-## File Version: 0.06
+## File Version: 0.07
 
 
 tam_mml_se_quick_likelihood <- function( nitems, A, AXsi, B, xsi, theta, nnodes, maxK,
-        gwt, resp, resp.ind.list, snodes, thetawidth )
+        gwt, resp, resp.ind.list, snodes, thetawidth, thetasamp.density = NULL )
 {
     # calculate probabilities
     res0 <- tam_mml_calc_prob( iIndex=1:nitems, A=A, AXsi=AXsi, B=B,
@@ -12,7 +12,7 @@ tam_mml_se_quick_likelihood <- function( nitems, A, AXsi, B, xsi, theta, nnodes,
     # calculate likelihood
     like0 <- tam_calc_posterior(rprobs=rprobs, gwt=gwt, resp=resp,
                                 nitems=nitems, resp.ind.list=resp.ind.list,
-                                normalization=FALSE, thetasamp.density=NULL,
+                                normalization=FALSE, thetasamp.density=thetasamp.density,
                                 snodes=snodes )$hwt
     # calculate individual log likelihood
     res <- tam_mml_se_quick_compute_log_likelihood( like0=like0,


### PR DESCRIPTION
Dear Alexander,
I have problems with standard error estimation via `tam.se()` for models that were estimated using QMC, see example below. I don't know if this is a feature or a bug. But in case it's a bug, I propose the committed changes. I tried a few examples and compared the SEs for models with and without QMC, and they were comparable IMHO. Feel free to adapt this to your needs.
Best, Hansjörg

``` r
library("TAM")
#> Loading required package: CDM
#> Loading required package: mvtnorm
#> **********************************
#> ** CDM 7.3-17 (2019-03-18 18:33:40)      
#> ** Cognitive Diagnostic Models  **
#> **********************************
#> * TAM 3.3-4 (2019-07-17 18:34:22)
packageVersion("TAM")
#> [1] '3.3.4'

# from ?tam.se

#############################################################################
# EXAMPLE 2: Standard errors differential item functioning
#############################################################################
data(data.ex08)

formulaA <- ~ item*female
resp <- data.ex08[["resp"]]
facets <- as.data.frame( data.ex08[["facets"]] )
# investigate DIF
mod <- TAM::tam.mml.mfr( resp=resp, facets=facets, formulaA=formulaA, verbose = FALSE)
#> --- Created person identifiers.
# summary(mod)
# estimate standard errors
semod <- TAM::tam.se(mod)
#> Item parameters
#> |**********|
#> |----------|
#> Regression parameters
#> |*|
#> ||
#> |-|

mod2 <- TAM::tam.mml.mfr( resp=resp, facets=facets, formulaA=formulaA, verbose = FALSE,
                          control = list(snodes = 2000))
#> --- Created person identifiers.
# summary(mod)
# estimate standard errors
semod2 <- TAM::tam.se(mod2)
#> Item parameters
#> |**********|
#> |
#> Error in matrix(thetasamp.density, nrow = nstud, ncol = ncol(gwt), byrow = TRUE): 'data' must be of a vector type, was 'NULL'
```

<sup>Created on 2019-07-19 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
